### PR TITLE
Update configuration.yaml.j2

### DIFF
--- a/templates/configuration.yaml.j2
+++ b/templates/configuration.yaml.j2
@@ -3,7 +3,7 @@ permit_join: {{ zigbee_permit_join }}
 mqtt: {{ zigbee_mqtt_defaults | combine(zigbee_mqtt) }}
 advanced: {{ zigbee_advanced_defaults | combine(zigbee_advanced) }}
 serial: {{ zigbee_serial_defaults | combine(zigbee_serial) }}
-frontend: {{ zigbee_frontend_defaults | combine(zigbee_frontend) if zigbee_frontend is mapping else zigbee_frontend}}
+frontend: {{ zigbee_frontend_defaults | combine(zigbee_frontend) if zigbee_frontend is mapping else zigbee_frontend }}
 ota: {{ zigbee_ota_defaults | combine(zigbee_ota) }}
 {% if zigbee_device_options is defined %}
 device_options: {{ zigbee_device_options }}
@@ -20,7 +20,7 @@ external_converters: {{ _zigbee_external_converters }}
 {% if zigbee_map_options is defined %}
 map_options: {{ zigbee_map_options }}
 {% endif %}
-availability: {{ zigbee_availability if zigbee_availability is defined else false}}
-homeassistant: {{ zigbee_homeassistant if zigbee_homeassistant is defined else false}}
-devices: devices.yaml
-groups: groups.yaml
+availability: {{ zigbee_availability if zigbee_availability is defined }}
+homeassistant: {{ zigbee_homeassistant if zigbee_homeassistant is defined }}
+devices: include devices.yaml
+groups: include groups.yaml


### PR DESCRIPTION
include correctly devices and groups. writing only the filename breaks the configuration in z2m v2